### PR TITLE
Bump chips-n-salsa from 4.8.0 to 5.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
 		<dependency>
 			<groupId>org.cicirello</groupId>
 			<artifactId>chips-n-salsa</artifactId>
-			<version>4.8.0</version>
+			<version>5.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.cicirello</groupId>


### PR DESCRIPTION
## Summary
Bump chips-n-salsa from 4.8.0 to 5.0.0
