### PR TITLE
Minor edit to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
  
 	<groupId>org.cicirello</groupId>
 	<artifactId>chips-n-salsa-examples</artifactId>
-	<version>5.0.0</version>
+	<version>5-SNAPSHOT</version>
 	<packaging>jar</packaging>
   
 	<name>Chips-n-Salsa Example Programs</name>


### PR DESCRIPTION
Changed version in pom.xml to a SNAPSHOT version to avoid confusion for anyone building locally. We inject the real version during release. It previously had an old version listed, which might confuse users building locally.
