### PR TITLE
Removed explicit declaration of transitive dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
  
 	<groupId>org.cicirello</groupId>
 	<artifactId>chips-n-salsa-examples</artifactId>
-	<version>5-SNAPSHOT</version>
+	<version>6-SNAPSHOT</version>
 	<packaging>jar</packaging>
   
 	<name>Chips-n-Salsa Example Programs</name>
@@ -144,21 +144,6 @@
 			<groupId>org.cicirello</groupId>
 			<artifactId>chips-n-salsa</artifactId>
 			<version>6.1.0</version>
-		</dependency>
-		<dependency>
-			<groupId>org.cicirello</groupId>
-			<artifactId>jpt</artifactId>
-			<version>4.3.0</version>
-		</dependency>
-		<dependency>
-			<groupId>org.cicirello</groupId>
-			<artifactId>rho-mu</artifactId>
-			<version>2.5.0</version>
-		</dependency>
-		<dependency>
-			<groupId>org.cicirello</groupId>
-			<artifactId>core</artifactId>
-			<version>2.4.3</version>
 		</dependency>
 	</dependencies>
   


### PR DESCRIPTION
## Summary
Removed explicit declaration of transitive dependencies. We previously needed to declare the dependencies of chips-n-salsa, in addition to declaring chips-n-salsa as a dependency due to a bug in the chips-n-salsa deployment workflow, which has publishing a dependency-reduced pom rather than the full pom (bug in how maven-shade-plugin was configured). This was fixed in chips-n-salsa 6.1.0, So only chips-n-salsa must be declared as a dependency. 
